### PR TITLE
Added a remove s3 flag

### DIFF
--- a/lib/deploy/synchronize-website.js
+++ b/lib/deploy/synchronize-website.js
@@ -11,7 +11,7 @@ module.exports = {
     let domain = context.config.domain
     let uploadDirectory = context.config.upload_directory
     let trailingSlashes = context.config.trailing_slashes
-    let shouldRemoveFilesInS3 = !!context.config.should_remove_files_in_s3 ? context.config.shouldRemoveFilesInS3 : true
+    let shouldKeepFilesInS3 = !!context.config.should_keep_files_in_s3 ? context.config.should_keep_files_in_s3 : false
 
     let targetKey = (path) => {
       if (path != "index.html" && path.endsWith("/index.html") && !trailingSlashes) {
@@ -83,7 +83,7 @@ module.exports = {
         ContentType: mime.getType(fullPath),
       })
     }
-    if (shouldRemoveFilesInS3) {
+    if (!shouldKeepFilesInS3) {
       for (let change of changes.remove) {
         task.output = `Removing ${change.key}`
   

--- a/lib/deploy/synchronize-website.js
+++ b/lib/deploy/synchronize-website.js
@@ -11,6 +11,7 @@ module.exports = {
     let domain = context.config.domain
     let uploadDirectory = context.config.upload_directory
     let trailingSlashes = context.config.trailing_slashes
+    let shouldRemoveFilesInS3 = !!context.config.should_remove_files_in_s3 ? context.config.shouldRemoveFilesInS3 : true
 
     let targetKey = (path) => {
       if (path != "index.html" && path.endsWith("/index.html") && !trailingSlashes) {
@@ -82,14 +83,15 @@ module.exports = {
         ContentType: mime.getType(fullPath),
       })
     }
-
-    for (let change of changes.remove) {
-      task.output = `Removing ${change.key}`
-
-      await context.s3.deleteObject({
-        Bucket: domain,
-        Key: change.key,
-      })
+    if (shouldRemoveFilesInS3) {
+      for (let change of changes.remove) {
+        task.output = `Removing ${change.key}`
+  
+        await context.s3.deleteObject({
+          Bucket: domain,
+          Key: change.key,
+        })
+      }
     }
   },
 }


### PR DESCRIPTION
added a new key for `config` to toggle the synchronization of files removed in the upload dir and s3. 

Set `should_remove_files_in_s3` to false if you do not want files to be removed if they are deleted locally in upload dir.